### PR TITLE
G3 upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ allprojects {
     jcenter()
     maven { url 'http://oss.jfrog.org/artifactory/oss-snapshot-local/' }
     mavenCentral()
+    maven { url "https://repo.grails.org/grails/core" }
   }
 
   ext {
@@ -20,7 +21,7 @@ allprojects {
     classmate = "1.3.4"
     groovy = "2.4.8"
     guava = "20.0"
-    grails = "3.2.4"
+    grails = "3.3.2"
     jackson = '2.7.7'
     joda = "2.9.4"
     jsonPath = "2.4.0"
@@ -31,7 +32,7 @@ allprojects {
     slf4j = "1.7.22"
     snakeyaml = '1.19'
     spock = "1.1-groovy-2.4"
-    spring = "4.2.8.RELEASE"
+    spring = "4.2.9.RELEASE"
     springHateoas = "0.21.0.RELEASE"
     springPluginVersion = "1.2.0.RELEASE"
     swagger2Core = "1.5.12"

--- a/springfox-grails-contract-tests/build.gradle
+++ b/springfox-grails-contract-tests/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsVersion"
-        classpath "org.grails.plugins:hibernate5:6.0.2"
-        classpath "org.grails.plugins:views-gradle:1.1.1"
+        classpath "org.grails.plugins:hibernate5:6.1.8"
+        classpath "org.grails.plugins:views-gradle:1.2.6"
     }
 }
 
@@ -60,12 +60,10 @@ dependencies {
     console "org.grails:grails-console"
 
     profile "org.grails.profiles:rest-api"
-
-    provided "org.codehaus.groovy:groovy-ant"
-  
     runtime "com.h2database:h2"
-  
-    testCompile "org.grails:grails-plugin-testing"
+    runtime "org.apache.tomcat:tomcat-jdbc"
+
+    testCompile "org.grails:grails-web-testing-support"
     testCompile "org.grails.plugins:geb"
     testCompile "org.grails:grails-datastore-rest-client"
     testCompile 'io.rest-assured:rest-assured:3.0.6'

--- a/springfox-grails-contract-tests/gradle.properties
+++ b/springfox-grails-contract-tests/gradle.properties
@@ -1,2 +1,2 @@
-grailsVersion=3.2.4
-gradleWrapperVersion=3.0
+grailsVersion=3.3.2
+gradleWrapperVersion=3.5

--- a/springfox-grails-contract-tests/grails-app/conf/application.yml
+++ b/springfox-grails-contract-tests/grails-app/conf/application.yml
@@ -63,7 +63,7 @@ hibernate:
         queries: false
         use_second_level_cache: true
         use_query_cache: false
-        region.factory_class: org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
+#        region.factory_class: org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
 
 dataSource:
     pooled: true

--- a/springfox-grails-contract-tests/grails-app/controllers/grails/springfox/sample/BookController.groovy
+++ b/springfox-grails-contract-tests/grails-app/controllers/grails/springfox/sample/BookController.groovy
@@ -1,6 +1,6 @@
 package grails.springfox.sample
 
-import grails.transaction.Transactional
+import grails.gorm.transactions.Transactional
 import io.swagger.annotations.ApiImplicitParam
 import io.swagger.annotations.ApiImplicitParams
 import io.swagger.annotations.ApiOperation

--- a/springfox-grails-contract-tests/src/integration-test/groovy/grails/springfox/sample/SpringFoxSpec.groovy
+++ b/springfox-grails-contract-tests/src/integration-test/groovy/grails/springfox/sample/SpringFoxSpec.groovy
@@ -1,6 +1,6 @@
 package grails.springfox.sample
 
-import grails.test.mixin.integration.Integration
+import grails.testing.mixin.integration.Integration
 import groovy.json.JsonOutput
 import org.junit.Assert
 import org.skyscreamer.jsonassert.JSONAssert

--- a/springfox-grails/build.gradle
+++ b/springfox-grails/build.gradle
@@ -18,6 +18,7 @@ buildscript {
     maven {
       url "https://plugins.gradle.org/m2/"
     }
+    maven { url "https://repo.grails.org/grails/core" }
     jcenter()
     mavenCentral()
   }
@@ -49,7 +50,6 @@ dependencies {
     testCompile "org.spockframework:spock-spring:${spock}"
     testCompile "org.spockframework:spock-core:${spock}"
     testCompile "org.codehaus.groovy:groovy-all:${groovy}"
-    testCompile "org.grails:grails-plugin-testing:${grails}"
     testCompile "org.grails:grails-plugin-rest:${grails}"
 
     provided "io.swagger:swagger-annotations:${swagger2Core}"

--- a/springfox-grails/src/main/java/springfox/documentation/grails/SpringfoxGrailsIntegrationConfiguration.java
+++ b/springfox-grails/src/main/java/springfox/documentation/grails/SpringfoxGrailsIntegrationConfiguration.java
@@ -1,9 +1,19 @@
 package springfox.documentation.grails;
 
+import com.fasterxml.classmate.TypeResolver;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import springfox.documentation.spi.service.RequestHandlerProvider;
+import springfox.documentation.spi.service.contexts.Defaults;
+import springfox.documentation.spring.web.DocumentationCache;
+import springfox.documentation.spring.web.plugins.DocumentationPluginsBootstrapper;
+import springfox.documentation.spring.web.plugins.DocumentationPluginsManager;
+import springfox.documentation.spring.web.scanners.ApiDocumentationScanner;
+
+import javax.servlet.ServletContext;
+import java.util.List;
 
 @Configuration
 @ComponentScan(basePackages = "springfox.documentation.grails")
@@ -25,5 +35,25 @@ public class SpringfoxGrailsIntegrationConfiguration {
   @ConditionalOnMissingBean(GeneratedClassNamingStrategy.class)
   public GeneratedClassNamingStrategy namingStrategy() {
     return new DefaultGeneratedClassNamingStrategy();
+  }
+
+  @Bean
+  DocumentationPluginsBootstrapper documentationPluginsBootstrapper(
+          DocumentationPluginsManager documentationPluginsManager,
+          List<RequestHandlerProvider> handlerProviders,
+          DocumentationCache scanned,
+          ApiDocumentationScanner resourceListing,
+          TypeResolver typeResolver,
+          Defaults defaults,
+          ServletContext servletContext) {
+
+    return new SwaggerDocumentationPluginsBootstrapper(
+            documentationPluginsManager,
+            handlerProviders,
+            scanned,
+            resourceListing,
+            typeResolver,
+            defaults,
+            servletContext);
   }
 }

--- a/springfox-grails/src/main/java/springfox/documentation/grails/SwaggerDocumentationPluginsBootstrapper.java
+++ b/springfox-grails/src/main/java/springfox/documentation/grails/SwaggerDocumentationPluginsBootstrapper.java
@@ -1,0 +1,31 @@
+package springfox.documentation.grails;
+
+import com.fasterxml.classmate.TypeResolver;
+import springfox.documentation.spi.service.RequestHandlerProvider;
+import springfox.documentation.spi.service.contexts.Defaults;
+import springfox.documentation.spring.web.DocumentationCache;
+import springfox.documentation.spring.web.plugins.DocumentationPluginsBootstrapper;
+import springfox.documentation.spring.web.plugins.DocumentationPluginsManager;
+import springfox.documentation.spring.web.scanners.ApiDocumentationScanner;
+
+import javax.servlet.ServletContext;
+import java.util.List;
+
+public class SwaggerDocumentationPluginsBootstrapper extends DocumentationPluginsBootstrapper {
+
+        SwaggerDocumentationPluginsBootstrapper(DocumentationPluginsManager documentationPluginsManager,
+                                                List<RequestHandlerProvider> handlerProviders,
+                                                DocumentationCache scanned,
+                                                ApiDocumentationScanner resourceListing,
+                                                TypeResolver typeResolver,
+                                                Defaults defaults,
+                                                ServletContext servletContext) {
+            super(documentationPluginsManager, handlerProviders, scanned, resourceListing, typeResolver, defaults, servletContext);
+        }
+
+        @Override
+        public boolean isAutoStartup() {
+            return false;
+        }
+
+}

--- a/springfox-grails/src/main/java/springfox/documentation/grails/SwaggerGrailsApplicationPostProcessor.java
+++ b/springfox-grails/src/main/java/springfox/documentation/grails/SwaggerGrailsApplicationPostProcessor.java
@@ -1,0 +1,39 @@
+package springfox.documentation.grails;
+
+import grails.core.GrailsApplicationLifeCycle;
+import groovy.lang.Closure;
+import org.springframework.stereotype.Component;
+import springfox.documentation.spring.web.plugins.DocumentationPluginsBootstrapper;
+
+import java.util.Map;
+
+
+@Component
+public class SwaggerGrailsApplicationPostProcessor  implements GrailsApplicationLifeCycle {
+
+    private DocumentationPluginsBootstrapper documentationPluginsBootstrapper;
+
+    public SwaggerGrailsApplicationPostProcessor(DocumentationPluginsBootstrapper documentationPluginsBootstrapper){
+        this.documentationPluginsBootstrapper = documentationPluginsBootstrapper;
+    }
+
+    @Override
+    public Closure doWithSpring() { return null; }
+
+    @Override
+    public void doWithDynamicMethods() {}
+
+    @Override
+    public void doWithApplicationContext() {}
+
+    @Override
+    public void onConfigChange(Map<String, Object> event) {}
+
+    @Override
+    public void onStartup(Map<String, Object> event) {
+        documentationPluginsBootstrapper.start();
+    }
+
+    @Override
+    public void onShutdown(Map<String, Object> event) {}
+}

--- a/springfox-grails/src/main/java/springfox/documentation/grails/UrlMappings.java
+++ b/springfox-grails/src/main/java/springfox/documentation/grails/UrlMappings.java
@@ -4,7 +4,7 @@ import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.classmate.TypeResolver;
 import com.google.common.base.Strings;
 import grails.core.GrailsDomainClass;
-import grails.validation.ConstrainedProperty;
+import grails.gorm.validation.ConstrainedProperty;
 import grails.web.mapping.UrlMapping;
 import springfox.documentation.service.ResolvedMethodParameter;
 
@@ -36,7 +36,7 @@ class UrlMappings {
   }
 
   public static Map<String, String> pathParameters(UrlMapping mapping) {
-    ConstrainedProperty[] constraints = mapping.getConstraints();
+    ConstrainedProperty[] constraints = (ConstrainedProperty[])mapping.getConstraints();
     return IntStream.range(0, constraints.length)
         .filter(indicesToUse(mapping))
         .mapToObj(i -> constraints[i])
@@ -49,7 +49,7 @@ class UrlMappings {
       TypeResolver resolver,
       UrlMapping mapping,
       GrailsDomainClass domainClass) {
-    ConstrainedProperty[] constraints = mapping.getConstraints();
+    ConstrainedProperty[] constraints = (ConstrainedProperty[])mapping.getConstraints();
     List<ConstrainedProperty> pathProperties = IntStream.range(0, constraints.length)
         .filter(indicesToUse(mapping))
         .mapToObj(i -> constraints[i])
@@ -68,7 +68,7 @@ class UrlMappings {
 
   private static IntPredicate indicesToUse(UrlMapping mapping) {
     return index -> {
-      ConstrainedProperty property = mapping.getConstraints()[index];
+      ConstrainedProperty property = (ConstrainedProperty)mapping.getConstraints()[index];
       return !property.getPropertyName().equals("controller")
           && !property.getPropertyName().equals("action")
           && !property.isNullable();
@@ -120,7 +120,7 @@ class UrlMappings {
   }
 
   private static boolean hasControllerConstraint(UrlMapping urlMapping, String name) {
-    return !Arrays.stream(urlMapping.getConstraints())
+    return !Arrays.stream((ConstrainedProperty[])urlMapping.getConstraints())
         .filter(c -> c.getPropertyName().equals(name))
         .collect(Collectors.toList()).isEmpty();
   }

--- a/springfox-grails/src/test/groovy/springfox/documentation/grails/IndexActionSpecificationFactorySpec.groovy
+++ b/springfox-grails/src/test/groovy/springfox/documentation/grails/IndexActionSpecificationFactorySpec.groovy
@@ -1,9 +1,9 @@
 package springfox.documentation.grails
 
 import com.fasterxml.classmate.TypeResolver
-import grails.rest.RestfulController
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.RequestMethod
+
 
 class IndexActionSpecificationFactorySpec extends ActionSpecificationFactorySpec {
   def "Index action produces action specification" () {
@@ -17,7 +17,7 @@ class IndexActionSpecificationFactorySpec extends ActionSpecificationFactorySpec
       spec.consumes == [MediaType.APPLICATION_JSON] as Set
       spec.produces == [MediaType.APPLICATION_JSON] as Set
       spec.supportedMethods == [RequestMethod.GET] as Set
-      spec.handlerMethod.method == RestfulController.declaredMethods.find {it.name == "index" }
+      (AController.methods.findAll {it.name == "index" }).contains(spec.handlerMethod.method)
       spec.path == "/a"
 
     and: "Parameters match"


### PR DESCRIPTION
@dilipkrish I have went through and got the project working with Grails 3.3.2. This update gets the dependencies and imports updated correctly. The other major change made is to have the DocumentationPluginsBootstrapper not startup with the Spring context but with the Grails Application through the SwaggerGrailsApplicationPostProcessor.onStartup method. This is similar to the way Springs SmartLifecycle interface works but in the context of Grails lifecycle.

I saw the changes in the issue/18 branch but didn't have time to integrate all the changes. I figure this is a release that could be put out sooner to get basic Grails 3.3.X support working. I believe it will be compatible with any Grails 3.X version as well, so backwards compatible, but I haven't fully confirmed that.